### PR TITLE
Do not redefine the dialer

### DIFF
--- a/module.go
+++ b/module.go
@@ -85,7 +85,7 @@ func (mi *ModuleInstance) GetCertificate(target string) *sobek.Promise {
 			// expired certificate will return an error
 			InsecureSkipVerify: true,
 		})
-		if err := conn.Handshake(); err != nil {
+		if err := conn.HandshakeContext(mi.vu.Context()); err != nil {
 			reject(err)
 			return
 		}

--- a/module_test.go
+++ b/module_test.go
@@ -118,7 +118,7 @@ func newTestDialer() *netext.Dialer {
 	}, nil)
 
 	trie, err := types.NewHostnameTrie([]string{"blocked.net"})
-	if err != err {
+	if err != nil {
 		panic(err)
 	}
 	d.BlockedHostnames = trie


### PR DESCRIPTION
We don't want to rewrite the logic for blocked hostnames/ips. Refactor the code to transition to a code that better supports the re-use of the existing logic.